### PR TITLE
Some additions test

### DIFF
--- a/asciidoc-hs.cabal
+++ b/asciidoc-hs.cabal
@@ -24,12 +24,12 @@ library
                        Text.AsciiDoc.SourceRange
                        Text.AsciiDoc.Token
   -- other-modules:
-  build-depends:       base ^>= 4.14.0.0,
-                       optics-core == 0.3.*,
-                       pandoc-types == 1.21.*,
-                       parsec == 3.1.*,
-                       parser-combinators == 1.2.*,
-                       text == 1.2.*
+  build-depends:       base >= 4.12.0.0,
+                       optics-core >= 0.2,
+                       pandoc-types >= 1.20,
+                       parsec >= 3.1.0,
+                       parser-combinators >= 1.2.0,
+                       text >= 1.2.0
   default-language:    Haskell2010
   default-extensions:  LambdaCase,
                        OverloadedStrings
@@ -50,10 +50,10 @@ executable asciidoc-hs
   main-is:             Main.hs
   -- other-modules:
   build-depends:       asciidoc-hs,
-                       aeson == 1.5.*,
-                       base ^>= 4.14.0.0,
-                       parsec == 3.1.*,
-                       text == 1.2.*
+                       aeson >= 1.4.7,
+                       base >= 4.12.0.0,
+                       parsec >= 3.1.0,
+                       text >= 1.2.0
   default-language:    Haskell2010
   default-extensions:  LambdaCase,
                        OverloadedStrings
@@ -74,9 +74,9 @@ test-suite asciidoc-hs-test
   hs-source-dirs:      test
   main-is:             Tests/InlineTests.hs
   build-depends:       asciidoc-hs,
-                       base ^>= 4.14.0.0,
-                       parsec == 3.1.*,
-                       pretty-show == 1.10.*,
+                       base >= 4.12.0.0,
+                       parsec >= 3.1.0,
+                       pretty-show >= 1.10,
                        tasty,
                        tasty-hunit
   default-language:    Haskell2010

--- a/src/Text/AsciiDoc/Blocks.hs
+++ b/src/Text/AsciiDoc/Blocks.hs
@@ -290,11 +290,16 @@ pParagraphLine = satisfyToken f
     f (UnparsedLine t) | T.any (not . isSpace) t = Just t
     f _ = Nothing
 
--- XXX: Does not match whitespace after <<<
 pPageBreak :: Parser (Block [BlockPrefixItem])
 pPageBreak = PageBreak [] <$ satisfyToken f
   where
-    f (UnparsedLine t) | t == "<<<" = Just ()
+    f (UnparsedLine t) =
+      let
+        (p,s) = T.splitAt 3 t
+      in
+        if p == "<<<" && T.all (== ' ') s
+        then Just ()
+        else Nothing
     f _ = Nothing
 
 parseTest :: Parser a -> [Token Text] -> Either Parsec.ParseError a

--- a/src/Text/AsciiDoc/Blocks.hs
+++ b/src/Text/AsciiDoc/Blocks.hs
@@ -42,6 +42,7 @@ module Text.AsciiDoc.Blocks
   )
 where
 
+import Control.Applicative ((<|>))
 import Control.Monad.Combinators (eitherP, many, optional)
 import Control.Monad.Combinators.NonEmpty
 import Data.Char (isSpace)
@@ -259,7 +260,7 @@ pBlock =
   f <$> many pBlockPrefixItem <*> pBlock'
   where
     pBlock' =
-      pParagraph
+      pPageBreak <|> pParagraph
     f blockPrefix block = fmap (const blockPrefix) block
 
 pBlockPrefixItem :: Parser BlockPrefixItem
@@ -287,6 +288,13 @@ pParagraphLine = satisfyToken f
   where
     -- TODO. Also check no indentation.
     f (UnparsedLine t) | T.any (not . isSpace) t = Just t
+    f _ = Nothing
+
+-- XXX: Does not match whitespace after <<<
+pPageBreak :: Parser (Block [BlockPrefixItem])
+pPageBreak = PageBreak [] <$ satisfyToken f
+  where
+    f (UnparsedLine t) | t == "<<<" = Just ()
     f _ = Nothing
 
 parseTest :: Parser a -> [Token Text] -> Either Parsec.ParseError a

--- a/src/Text/AsciiDoc/Inlines.hs
+++ b/src/Text/AsciiDoc/Inlines.hs
@@ -107,7 +107,9 @@ defaultScopes =
     Scope "__" "__" Unconstrained Any,
     Scope "_" "_" Constrained Any,
     Scope "``" "``" Unconstrained Any,
-    Scope "`" "`" Constrained Any
+    Scope "`" "`" Constrained Any,
+    Scope "~" "~" Constrained Any,
+    Scope "^" "^" Constrained Any
   ]
 
 -- | Association list.
@@ -153,6 +155,8 @@ data Style
   | Custom
   | Italic
   | Monospace
+  | Subscript
+  | Superscript
   deriving (Eq, Show)
 
 makeInline ::
@@ -171,6 +175,8 @@ makeInline scope ps open is close = case scope of
   Scope "_" _ _ _ -> StyledText Italic ps open is close
   Scope "``" _ _ _ -> StyledText Monospace ps open is close
   Scope "`" _ _ _ -> StyledText Monospace ps open is close
+  Scope "~" _ _ _ -> StyledText Subscript ps open is close
+  Scope "^" _ _ _ -> StyledText Superscript ps open is close
   _ -> InlineSeq is
 
 pPutAcceptConstrained :: AcceptConstrained -> Parser ()


### PR DESCRIPTION
I tried to add a block (page breaks) and two inlines (subscripts and superscripts). On the good side, I think I did something that is minimally functional without knowing the code base, that's good!

However, it was not always evident to know where to go in the file to focus on the functionality that matters. In these cases, I like to split the file into sections, using a line with 80 `-` and a section title below. This is not perfect, but forces some kind of explicit organization in the code.

Some more specific difficulties I had:

- I didn't know how to manage `BlockPrefixItem`. Could this be standardized in some way? I just added an empty list, but I am certainly ignoring information.
- I used `Scope`, but by supposing what it means. Some documentation on these fundamental types, that will certainly be manipulated by contributors, would be very useful.
- I did no changes on how Pandoc interprets the new things I added. Maybe there is a catch-all pattern somewhere? Giving pattern-matching errors when adding new constructors is good.

On a side note, I lowered some of the Cabal bounds, to make it possible to build on my system, that is a little outdated. This builds correctly, so that's positive - that makes it easier for contributors. I would recommend to add a `stack.yaml` to the repository, many people use Stack, and Stackage is a good reference on what's the currently acceptable bleeding edge.
